### PR TITLE
Update OTRizer version for zbank fix

### DIFF
--- a/.github/workflows/generate-soh-archive.yml
+++ b/.github/workflows/generate-soh-archive.yml
@@ -14,7 +14,7 @@ jobs:
       run: |
         cd data
         find . -type f -name '*.ootrs' | while read filename; do unzip -o -d "./Music/`basename -s .ootrs "$filename"`" "$filename"; done;
-        wget https://github.com/leggettc18/SequenceOTRizer/releases/download/v0.3/SequenceOTRizer-0.2-Linux.tar.gz
+        wget https://github.com/leggettc18/SequenceOTRizer/releases/download/v0.4/SequenceOTRizer-0.2-Linux.tar.gz
         tar -xzvf SequenceOTRizer-0.2-Linux.tar.gz
         ./SequenceOTRizer --seq-path Music --otr-name daruniasjoy
 


### PR DESCRIPTION
Had to modify the way OTRizer excluded soundbank mods to handle instances where the .zbank file doesn't have the same name as the .seq it's associated with.