### PR TITLE
Update make_title_screen_files.py

### DIFF
--- a/make_title_screen_files.py
+++ b/make_title_screen_files.py
@@ -73,7 +73,7 @@ def main():
                     continue
 
             sequence_slot = "Fairy Fountain"
-            if seq_type == "fanfare":
+            if seq_type.lower() == "fanfare":
                 sequence_slot = "Zelda's Lullaby"
 
             cosmetic_plando = {
@@ -82,7 +82,7 @@ def main():
                 },
             }
             with open(f'{cosmetic_plando_filename}', 'w', encoding='utf-8', newline='') as file:
-                json.dump(cosmetic_plando, file, indent=4)
+                json.dump(cosmetic_plando, file, indent=4, ensure_ascii = False)
 
             rando_settings = {
                 "enable_cosmetic_file": True,


### PR DESCRIPTION
If seq_type was "Fanfare" with caps, sequence_slot wouldn't be ZL.

Song titles (notably Pokémon) with accents became unicode escape in the cosmetic_plando.json files, so the randomizer wouldn't get the correct song title and fail to generate properly.