### PR TITLE
Update generate-soh-archive.yml

### DIFF
--- a/.github/workflows/generate-soh-archive.yml
+++ b/.github/workflows/generate-soh-archive.yml
@@ -24,30 +24,7 @@ jobs:
         name: daruniasjoy.otr
         path: data/mods
 
-
-    - name: List all releases
-      run: |
-        releases=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          https://api.github.com/repos/${{ github.repository }}/releases)
-        echo "$releases" | jq -r '.[].id' > release_ids.txt
-  
-    - name: Delete all releases
-      run: |
-        while IFS= read -r release_id; do
-          curl -X DELETE -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            https://api.github.com/repos/${{ github.repository }}/releases/$release_id
-        done < release_ids.txt
-
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: latest
-        draft: false
-        prerelease: false
-
-    - name: Upload Release Asset
       uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,3 +32,5 @@ jobs:
         files: data/mods/daruniasjoy.otr
         tag_name: latest
         name: Ship of Harkinian Bundle
+        draft: false
+        prerelease: false


### PR DESCRIPTION
Removes redundant steps, some of which caused failure states. Workflow was failing because of `softprops/action-gh-release@v2` being used twice, and that action also automatically updates existing releases and replaces release assets.